### PR TITLE
fix: unwrap action parameters and capture query settings in v2 protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,10 @@ ipython_config.py
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
 #poetry.lock
 
+# uv
+#   Like other lock files, commonly ignored for libraries.
+uv.lock
+
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
 #pdm.lock

--- a/pyflowlauncher/launcher.py
+++ b/pyflowlauncher/launcher.py
@@ -115,7 +115,16 @@ class FlowLauncherV2(Launcher):
 
             params = request.get('params', request.get('parameters', []))
             if method == 'query' and params and isinstance(params[0], dict):
+                # The host sends ("query", [query, Settings.Inner]).
+                if len(params) > 1 and isinstance(params[1], dict):
+                    self._settings = params[1]
                 params = [params[0].get('search') or params[0].get('trimmedQuery', '')]
+            elif method != 'context_menu' and len(params) == 1 and isinstance(params[0], list):
+                # Actions: the host calls RPC.InvokeAsync(method, argument: Parameters),
+                # which wraps the whole Parameters list as one positional argument
+                # (params=[[p1, p2]]). Unwrap so methods get their parameters like V1.
+                # context_menu is excluded: its single list argument IS the ContextData.
+                params = params[0]
 
             task = asyncio.create_task(
                 self._handle_request(request_id, method, params, dispatch)

--- a/tests/integration/test_v2_protocol.py
+++ b/tests/integration/test_v2_protocol.py
@@ -282,7 +282,112 @@ class TestV2ErrorHandling:
         assert query_response(responses, 1)['result']['result'][0]['Title'] == 'Hello, ok!'
 
 
+class TestV2Actions:
+    """Action execution (JsonRPCAction) over the V2 protocol.
+
+    Flow Launcher V2 executes actions via StreamJsonRpc's
+    RPC.InvokeAsync(method, argument: Parameters) — the single-argument
+    overload, which wraps the whole Parameters list in a one-element array:
+    the wire is params=[[p1, p2]], unlike V1's parameters=[p1, p2].
+    """
+
+    def _plugin_with_action(self, calls: list) -> Plugin:
+        plugin = Plugin(launcher=FlowLauncherV2())
+
+        @plugin.on_method
+        def my_action(a, b):
+            calls.append((a, b))
+
+        @plugin.on_method
+        def no_arg_action():
+            calls.append(())
+
+        return plugin
+
+    def test_action_parameters_unwrapped(self):
+        calls = []
+        plugin = self._plugin_with_action(calls)
+        run(plugin, [
+            {'id': 1, 'method': 'my_action', 'params': [['a', 'b']]},
+            {'id': 2, 'method': 'close', 'params': []},
+        ])
+        assert calls == [('a', 'b')]
+
+    def test_action_with_empty_parameters(self):
+        calls = []
+        plugin = self._plugin_with_action(calls)
+        run(plugin, [
+            {'id': 1, 'method': 'no_arg_action', 'params': [[]]},
+            {'id': 2, 'method': 'close', 'params': []},
+        ])
+        assert calls == [()]
+
+    def test_action_response_is_execute_response(self):
+        """Flow deserializes the result as JsonRPCExecuteResponse(bool Hide = true),
+        so both {} and {'hide': True} mean 'hide the window'."""
+        calls = []
+        plugin = self._plugin_with_action(calls)
+        responses = run(plugin, [
+            {'id': 1, 'method': 'my_action', 'params': [['a', 'b']]},
+            {'id': 2, 'method': 'close', 'params': []},
+        ])
+        assert query_response(responses, 1)['result'] in ({}, {'hide': True})
+
+    def test_context_menu_receives_context_data_as_single_argument(self):
+        """context_menu keeps V1 parity: one argument, the ContextData list.
+
+        Flow V2 sends params=[ContextData] (InvokeWithCancellationAsync with a
+        one-element argument array) — it must NOT be unwrapped like actions.
+        """
+        received = []
+        plugin = Plugin(launcher=FlowLauncherV2())
+
+        @plugin.on_method
+        def context_menu(data):
+            received.append(data)
+            return Result(title="ctx item")
+
+        run(plugin, [
+            {'id': 1, 'method': 'context_menu', 'params': [['ctx1', 'ctx2']]},
+            {'id': 2, 'method': 'close', 'params': []},
+        ])
+        assert received == [['ctx1', 'ctx2']]
+
+
 class TestV2Settings:
+
+    def test_settings_stored_from_query_params(self):
+        """V2 sends settings as the second query param:
+        RPC.InvokeWithCancellationAsync("query", new object[] { query, Settings.Inner })."""
+        plugin = Plugin(launcher=FlowLauncherV2())
+
+        @plugin.on_method
+        def query(q: str):
+            yield Result(title="ok")
+
+        run(plugin, [
+            {'id': 1, 'method': 'query',
+             'params': [{'search': 'x', 'trimmedQuery': 'x'}, {'api_key': 'secret'}]},
+            {'id': 2, 'method': 'close', 'params': []},
+        ])
+        assert plugin._launcher.settings == {'api_key': 'secret'}
+
+    def test_query_settings_param_not_passed_to_handler(self):
+        """The settings dict must be consumed, not passed as a query argument."""
+        received = []
+        plugin = Plugin(launcher=FlowLauncherV2())
+
+        @plugin.on_method
+        def query(*args):
+            received.append(args)
+            yield Result(title="ok")
+
+        run(plugin, [
+            {'id': 1, 'method': 'query',
+             'params': [{'search': 'x'}, {'api_key': 'secret'}]},
+            {'id': 2, 'method': 'close', 'params': []},
+        ])
+        assert received == [('x',)]
 
     def test_settings_stored_from_request(self):
         plugin = Plugin(launcher=FlowLauncherV2())


### PR DESCRIPTION
## Problem

In the V2 (`python_v2`) protocol, methods registered via `Result.add_action` were triggered without their parameters — multi-parameter methods failed with a swallowed `TypeError` ("Internal error" response), and single-parameter methods received the whole parameters list as one argument. This also broke actions attached to context-menu results. Additionally, `plugin.settings` was never populated under V2.

## Root cause

Flow Launcher's V2 host executes actions via StreamJsonRpc's single-argument overload:

```csharp
RPC.InvokeAsync<JsonRPCExecuteResponse>(result.JsonRPCAction.Method, argument: result.JsonRPCAction.Parameters);
```

That overload wraps the entire `Parameters` list in a one-element array, so the wire message is `"params": [["a", "b"]]` — unlike V1's `"parameters": ["a", "b"]`. `FlowLauncherV2.run` passed it straight to `dispatch(method, *params)`, giving the method one list argument instead of its unpacked parameters.

Settings are sent by the V2 host as the second query param (`InvokeWithCancellationAsync("query", new object[] { query, Settings.Inner })`), but only a top-level `settings` key was being read.

## Changes

- `FlowLauncherV2.run` unwraps the single-element list wrapping for action methods before dispatch. `context_menu` is explicitly excluded (its single list argument *is* the ContextData, matching V1 behavior), and `query` keeps its existing special case.
- `FlowLauncherV2.run` stores `params[1]` of query requests as the launcher settings; the top-level `settings` key remains as a fallback.
- New integration tests: `TestV2Actions` (parameters unwrapped, empty-parameter actions, execute-response shape, context_menu V1 parity) and two `TestV2Settings` cases (settings captured from query params and not leaked into handler arguments).
- Ignore `uv.lock`.

Reapplies 342574f and fe2376e (reverted off `main` in 0f5d2bc/c056e77 so this lands via PR review).