### PR TITLE
feat: honor $/cancelRequest by cancelling the in-flight task

### DIFF
--- a/pyflowlauncher/launcher.py
+++ b/pyflowlauncher/launcher.py
@@ -4,7 +4,7 @@ import asyncio
 import os
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable, Dict, Optional
 
 from .api import Api
 from .base import pyFlowLauncherObject
@@ -95,6 +95,7 @@ class FlowLauncherV2(Launcher):
 
     async def run(self, dispatch: Callable[[str, list], Awaitable[Any]]) -> None:
         tasks: set = set()
+        in_flight: Dict[Any, asyncio.Task] = {}
         async for request in self._client.messages():
             request_id = request.get('id')
             method = request.get('method', '')
@@ -108,6 +109,17 @@ class FlowLauncherV2(Launcher):
 
             if method in self._LIFECYCLE_METHODS:
                 self._respond(request_id, {})
+                continue
+
+            if method == '$/cancelRequest':
+                # StreamJsonRpc cancels a superseded request (e.g. the user kept
+                # typing) with params {'id': <request id>}. Cancel the in-flight
+                # task so slow queries stop doing work nobody will see.
+                cancel_params = request.get('params')
+                cancel_id = cancel_params.get('id') if isinstance(cancel_params, dict) else None
+                cancelled = in_flight.get(cancel_id)
+                if cancelled is not None:
+                    cancelled.cancel()
                 continue
 
             if method.startswith('$/'):
@@ -132,7 +144,14 @@ class FlowLauncherV2(Launcher):
                 self._handle_request(request_id, method, params, dispatch)
             )
             tasks.add(task)
-            task.add_done_callback(tasks.discard)
+            if request_id is not None:
+                in_flight[request_id] = task
+
+            def _cleanup(done: asyncio.Task, rid: Any = request_id) -> None:
+                tasks.discard(done)
+                if in_flight.get(rid) is done:
+                    del in_flight[rid]
+            task.add_done_callback(_cleanup)
 
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
@@ -146,6 +165,13 @@ class FlowLauncherV2(Launcher):
     ) -> None:
         try:
             result = await dispatch(method, params)
+        except asyncio.CancelledError:
+            # StreamJsonRpc's RequestCanceled error; the host discards it, but
+            # answering every request keeps the envelope contract uniform.
+            self._client.send({'id': request_id, 'result': None, 'error': {
+                'code': -32800, 'message': 'Request cancelled',
+            }})
+            raise
         except Exception:
             self.logger.exception("Unhandled error dispatching %r", method)
             self._respond(request_id, {

--- a/tests/integration/test_v2_protocol.py
+++ b/tests/integration/test_v2_protocol.py
@@ -203,6 +203,50 @@ class TestV2Lifecycle:
         assert 'query' not in dispatched
 
 
+class TestV2Cancellation:
+
+    def test_cancel_request_cancels_in_flight_query(self):
+        """$/cancelRequest must stop a slow query instead of letting it finish."""
+        plugin = Plugin(launcher=FlowLauncherV2())
+        completed = []
+
+        @plugin.on_method
+        async def query(q: str):
+            await asyncio.sleep(5)
+            completed.append(q)
+            return Result(title="too late")
+
+        responses = run(plugin, [
+            {'id': 1, 'method': 'query', 'params': [{'search': 'slow'}, {}]},
+            {'method': '$/cancelRequest', 'params': {'id': 1}},
+            {'id': 2, 'method': 'close', 'params': []},
+        ])
+        assert completed == []
+        resp = query_response(responses, 1)
+        assert resp['result'] is None
+        assert resp['error']['code'] == -32800
+
+    def test_cancel_unknown_id_is_ignored(self):
+        plugin = make_plugin()
+        responses = run(plugin, [
+            {'method': '$/cancelRequest', 'params': {'id': 99}},
+            {'id': 1, 'method': 'query', 'params': [{'search': 'World'}, {}]},
+            {'id': 2, 'method': 'close', 'params': []},
+        ])
+        assert query_response(responses, 1)['result']['result'][0]['Title'] == 'Hello, World!'
+        assert all(r.get('id') != 99 for r in responses)
+
+    def test_cancel_with_malformed_params_is_ignored(self):
+        plugin = make_plugin()
+        responses = run(plugin, [
+            {'method': '$/cancelRequest'},
+            {'method': '$/cancelRequest', 'params': [1]},
+            {'id': 1, 'method': 'query', 'params': [{'search': 'World'}, {}]},
+            {'id': 2, 'method': 'close', 'params': []},
+        ])
+        assert query_response(responses, 1)['result']['result'][0]['Title'] == 'Hello, World!'
+
+
 class TestV2Notifications:
 
     def test_cancel_request_silently_ignored(self):


### PR DESCRIPTION
## Summary

Flow Launcher fires a query per keystroke and cancels the superseded one with a `$/cancelRequest` notification (StreamJsonRpc's cancellation protocol, params `{"id": <request id>}`). The V2 launcher previously skipped the notification along with all other `$/` methods — protocol-safe, but stale queries kept running to completion. For plugins whose `query` does real async work (HTTP calls, disk scans), typing "weather" meant seven queries with six of them burning effort and rate limit on results nobody will see.

## Changes

- `FlowLauncherV2.run` tracks in-flight tasks by request id; `$/cancelRequest` cancels the matching task. Unknown ids, already-finished requests, and malformed params are ignored silently, as before.
- A cancelled request is answered with the JSON-RPC `RequestCanceled` error (`-32800`), which StreamJsonRpc recognizes and discards — every request still gets exactly one response.
- Other `$/` notifications remain silently skipped; `$/cancelRequest` is still never dispatched to plugin methods (existing test unchanged and passing).

## Caveat

`task.cancel()` interrupts at `await` points, so this benefits async plugin methods — exactly the slow ones. A synchronous method that blocks the event loop still runs to completion.

## Verification

`tox -e lint,type,py38,py312` all green — 137 tests, including three new ones: a slow async query is actually cancelled (asserted via a completion flag and the `-32800` response; the suite finishes in ~1s despite the test's 5s sleep, proving the cancel), unknown-id cancels are no-ops, and malformed params don't crash the loop.