### PR TITLE
fix: do not leak the action keyword into the v2 query search string

### DIFF
--- a/pyflowlauncher/launcher.py
+++ b/pyflowlauncher/launcher.py
@@ -118,7 +118,9 @@ class FlowLauncherV2(Launcher):
                 # The host sends ("query", [query, Settings.Inner]).
                 if len(params) > 1 and isinstance(params[1], dict):
                     self._settings = params[1]
-                params = [params[0].get('search') or params[0].get('trimmedQuery', '')]
+                # Query.search excludes the action keyword; trimmedQuery/rawQuery
+                # include it, so they must never be used as the search string.
+                params = [params[0].get('search') or '']
             elif method != 'context_menu' and len(params) == 1 and isinstance(params[0], list):
                 # Actions: the host calls RPC.InvokeAsync(method, argument: Parameters),
                 # which wraps the whole Parameters list as one positional argument

--- a/tests/integration/test_v2_protocol.py
+++ b/tests/integration/test_v2_protocol.py
@@ -129,6 +129,25 @@ class TestV2QueryFormat:
         ])
         assert query_response(responses, 1)['result']['result'][0]['Title'] == 'Hello, World!'
 
+    def test_action_keyword_not_leaked_into_search(self):
+        """Typing only the action keyword sends {'search': '', 'trimmedQuery': 'kw'};
+        the handler must receive '' — not fall back to the keyword-bearing trimmedQuery."""
+        received = []
+        plugin = Plugin(launcher=FlowLauncherV2())
+
+        @plugin.on_method
+        def query(q: str):
+            received.append(q)
+            yield Result(title="ok")
+
+        run(plugin, [
+            {'id': 1, 'method': 'query',
+             'params': [{'search': '', 'trimmedQuery': 'kw', 'rawQuery': 'kw',
+                         'actionKeyword': 'kw'}, {}]},
+            {'id': 2, 'method': 'close', 'params': []},
+        ])
+        assert received == ['']
+
 
 class TestV2Lifecycle:
 


### PR DESCRIPTION
## Summary
- Plugins using the `python_v2` protocol received the action keyword as their query string when the user had typed only the keyword (e.g. `wiki `).
- Flow Launcher serializes the whole `Query` object; `search` excludes the action keyword, but `trimmedQuery`/`rawQuery` include it. The falsy `or` fallback to `trimmedQuery` fired whenever `search` was an empty string, leaking the keyword to the handler.
- Drop the `trimmedQuery` fallback entirely — it can never be the correct search string.

## Test plan
- [x] New regression test `test_action_keyword_not_leaked_into_search` replays the real wire message (`{'search': '', 'trimmedQuery': 'kw', ...}`) and asserts the handler receives `''` (failed with `['kw'] != ['']` before the fix)
- [x] Full suite passes (135 tests)