### PR TITLE
ci: create a pre-release for code-changing merges to main

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -48,6 +48,16 @@ jobs:
           pip install -U pip build
           python -m build
 
+      - name: Delete previous pre-releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release list --json tagName,isPrerelease \
+            --jq '.[] | select(.isPrerelease) | .tagName' |
+          while read -r tag; do
+            gh release delete "$tag" --cleanup-tag --yes
+          done
+
       - name: Create pre-release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -20,7 +20,8 @@ jobs:
           startsWith(github.event.head_commit.message, 'fix') ||
           startsWith(github.event.head_commit.message, 'perf') ||
           startsWith(github.event.head_commit.message, 'refactor') ||
-          startsWith(github.event.head_commit.message, 'revert') }}
+          startsWith(github.event.head_commit.message, 'revert') ||
+          startsWith(github.event.head_commit.message, 'Revert') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -53,16 +54,6 @@ jobs:
           pip install -U pip build
           python -m build
 
-      - name: Delete previous pre-releases
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release list --json tagName,isPrerelease \
-            --jq '.[] | select(.isPrerelease) | .tagName' |
-          while read -r tag; do
-            gh release delete "$tag" --cleanup-tag --yes
-          done
-
       - name: Create pre-release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -72,3 +63,13 @@ jobs:
             --target "${{ github.sha }}" \
             --title "${{ steps.version.outputs.tag }}" \
             --generate-notes
+
+      - name: Delete previous pre-releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release list --json tagName,isPrerelease \
+            --jq '.[] | select(.isPrerelease and .tagName != "${{ steps.version.outputs.tag }}") | .tagName' |
+          while read -r tag; do
+            gh release delete "$tag" --cleanup-tag --yes
+          done

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -14,8 +14,13 @@ concurrency:
 
 jobs:
   prerelease:
-    # Skip release-please's release merge commits; those are handled by release-please.yaml
-    if: "${{ !startsWith(github.event.head_commit.message, 'chore(main): release') }}"
+    # Only cut a pre-release for commits that change shipped code
+    if: >-
+      ${{ startsWith(github.event.head_commit.message, 'feat') ||
+          startsWith(github.event.head_commit.message, 'fix') ||
+          startsWith(github.event.head_commit.message, 'perf') ||
+          startsWith(github.event.head_commit.message, 'refactor') ||
+          startsWith(github.event.head_commit.message, 'revert') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,0 +1,59 @@
+name: Pre-release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+concurrency:
+  group: prerelease
+  cancel-in-progress: true
+
+jobs:
+  prerelease:
+    # Skip release-please's release merge commits; those are handled by release-please.yaml
+    if: "${{ !startsWith(github.event.head_commit.message, 'chore(main): release') }}"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Compute dev version
+        id: version
+        run: |
+          # --exclude keeps the commit count relative to the last *stable* tag,
+          # so it stays monotonic across successive pre-releases
+          describe=$(git describe --tags --long --match 'v*' --exclude '*-dev*')  # e.g. v1.1.0-3-g2cdbbfd
+          last=${describe%-*-*}
+          counted=${describe%-*}
+          count=${counted##*-}
+          IFS=. read -r major minor patch <<< "${last#v}"
+          next="${major}.${minor}.$((patch + 1))"
+          echo "tag=v${next}-dev.${count}" >> "$GITHUB_OUTPUT"
+          echo "pep440=${next}.dev${count}" >> "$GITHUB_OUTPUT"
+
+      - name: Set version in pyproject.toml
+        run: sed -i "s/^version = \".*\"/version = \"${{ steps.version.outputs.pep440 }}\"/" pyproject.toml
+
+      - name: Build
+        run: |
+          pip install -U pip build
+          python -m build
+
+      - name: Create pre-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" dist/* \
+            --prerelease \
+            --target "${{ github.sha }}" \
+            --title "${{ steps.version.outputs.tag }}" \
+            --generate-notes

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -23,6 +23,24 @@ jobs:
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json
 
+  cleanup-prereleases:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Delete pre-releases and their tags
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release list --json tagName,isPrerelease \
+            --jq '.[] | select(.isPrerelease) | .tagName' |
+          while read -r tag; do
+            gh release delete "$tag" --cleanup-tag --yes
+          done
+
   build:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}


### PR DESCRIPTION
## Summary
- New `prerelease.yaml` workflow: on pushes to `main` whose commit type changes shipped code (`feat`, `fix`, `perf`, `refactor`, `revert` — scoped forms included), computes a next-patch dev version from the last stable tag (`v1.1.1-dev.N` / PEP 440 `1.1.1.devN`, N = commits since that tag), builds sdist + wheel with that version injected, and publishes them as a GitHub **pre-release**. Only the latest pre-release is kept — each run deletes prior pre-releases and their tags first. `chore`/`docs`/`ci` merges (including release-please's release commits) don't trigger builds.
- New `cleanup-prereleases` job in `release-please.yaml`: when a stable release is cut, the last remaining pre-release is deleted too.

No PAT required — both run on the default `GITHUB_TOKEN` with `contents: write`. (Cleanup lives inside `release-please.yaml` because `GITHUB_TOKEN`-created releases don't fire `release`-triggered workflows.)

## Verification
- Version-parsing logic tested locally against `git describe --long` output, including the count-0 and multi-digit cases.
- `sed` version injection + `uv build` tested locally: produces `pyflowlauncher-1.1.1.dev0.tar.gz` / `.whl`.
- Both workflow files pass YAML validation.
- Note: this PR's own `ci:` merge commit won't trigger a build — the first pre-release appears on the next feat/fix/perf/refactor/revert merge.