### PR TITLE
fix: strip the Flow.Launcher. namespace when forwarding built-in actions

### DIFF
--- a/pyflowlauncher/launcher.py
+++ b/pyflowlauncher/launcher.py
@@ -192,8 +192,11 @@ class FlowLauncherV2(Launcher):
         self._send_response(request_id, method, result)
 
     async def _handle_builtin_action(self, request_id: Any, method: str, params: list) -> None:
+        # The host registers JsonRPCPublicAPI under bare CLR method names
+        # (OpenAppUri, not Flow.Launcher.OpenAppUri), so strip the namespace.
+        host_method = method[len(NAME_SPACE) + 1:]
         try:
-            await self._client.request(method, params)
+            await self._client.request(host_method, params)
         except asyncio.CancelledError:
             self._client.send({'id': request_id, 'result': None, 'error': {
                 'code': -32800, 'message': 'Request cancelled',

--- a/tests/integration/test_v2_protocol.py
+++ b/tests/integration/test_v2_protocol.py
@@ -426,6 +426,11 @@ class TestV2BuiltinActions:
     method name back to this plugin process to run, exactly like a custom action. The
     plugin must recognize the Flow.Launcher. namespace and loop the call back to the
     host instead of trying to resolve it as one of its own @on_method handlers.
+
+    The host registers its API (JsonRPCPublicAPI) with StreamJsonRpc under bare CLR
+    method names (OpenAppUri, ChangeQuery, ...), the same names _fuzzy_search already
+    uses successfully, so the Flow.Launcher. prefix must be stripped when forwarding;
+    sending it verbatim dies with RemoteMethodNotFoundException on the host.
     """
 
     def test_builtin_action_forwarded_to_host_and_original_request_acked(self):
@@ -453,7 +458,8 @@ class TestV2BuiltinActions:
 
         asyncio.run(_inner())
 
-        forwarded = next(r for r in responses if r.get('method') == 'Flow.Launcher.OpenAppUri')
+        assert not any(r.get('method') == 'Flow.Launcher.OpenAppUri' for r in responses)
+        forwarded = next(r for r in responses if r.get('method') == 'OpenAppUri')
         assert forwarded['params'] == ['playnite://playnite/start/abc']
 
         original = query_response(responses, 10)


### PR DESCRIPTION
Follow-up to #36. That change looped built-in actions back to the host, but it forwarded the method name verbatim, e.g. Flow.Launcher.OpenAppUri. Flow's JsonRPCPluginV2 registers its JsonRPCPublicAPI methods with StreamJsonRpc under their bare CLR names (OpenAppUri, ChangeQuery, OpenSettingDialog, ...), so every forwarded call failed on the host with RemoteMethodNotFoundException while the plugin still answered hide: true. The net effect on 1.1.1: pressing Enter on a Result with any built-in json_rpc_action hid the launcher and did nothing.

The integration test from #36 asserted the namespaced name on the outgoing request, so it locked the bug in. It now asserts the bare name goes out (and that the namespaced form never does).

Fix: strip the Flow.Launcher. prefix before sending the request to the host. Error handling and the hide ack are unchanged.

Verified end to end in Flow on Windows with the Playnite plugin: launch, context menu actions, and settings dialog all work with this patch and were dead on 1.1.1.

Fixes #38.